### PR TITLE
3.6 Api "undefined" fixes

### DIFF
--- a/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.cssLayout.js
+++ b/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.cssLayout.js
@@ -104,7 +104,7 @@ var layoutLayersRecursively = function(styleTree, computedTree, currentX, curren
         layoutLayersRecursively(childStyleTree[i], childComputedTree[i], parentX, parentY, childLayer, shouldLayoutChildren);
       }
       // make sure group's bounds are re-set
-      [currentLayer resizeRoot:true];
+      [currentLayer resizeToFitChildrenWithOption:1];
     }
   }
 }

--- a/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.cssLayout.js
+++ b/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.cssLayout.js
@@ -38,7 +38,7 @@ var computeStyles = function(styleTree){
 // lay out all the layers given computed styles
 var layoutElements = function(styleTree, computedTree){
   layoutLayersRecursively(styleTree, computedTree, 0,0, page, false);
-  doc.currentView().refresh();
+  // doc.currentView().refresh();
 }
 
 // traverse all of the layers and lay out the elements


### PR DESCRIPTION
Two small commits to address API changes between 3.5 & 3.6. 

The layer resize method name update I'm pretty confident about. 

The document.refresh() command was also throwing an undefined error and commenting out the command doesn't seem to cause a problem but is probably not the best long term solution, but does get the plugin working again for now.
