### PR TITLE
fix: reflect sketch's API changes

### DIFF
--- a/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.cssLayout.js
+++ b/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.cssLayout.js
@@ -38,7 +38,6 @@ var computeStyles = function(styleTree){
 // lay out all the layers given computed styles
 var layoutElements = function(styleTree, computedTree){
   layoutLayersRecursively(styleTree, computedTree, 0,0, page, false);
-  doc.currentView().refresh();
 }
 
 // traverse all of the layers and lay out the elements
@@ -83,7 +82,7 @@ var layoutLayersRecursively = function(styleTree, computedTree, currentX, curren
 
   // iterate over children recursively if we can
   if (utils.is.group(currentLayer)){
-    var childLayers = [currentLayer layers].array();
+    var childLayers = [currentLayer layers];
     var childComputedTree = computedTree["children"];
     var childStyleTree = styleTree["children"];
     var parentX = currentLayer.frame.x;
@@ -104,7 +103,7 @@ var layoutLayersRecursively = function(styleTree, computedTree, currentX, curren
         layoutLayersRecursively(childStyleTree[i], childComputedTree[i], parentX, parentY, childLayer, shouldLayoutChildren);
       }
       // make sure group's bounds are re-set
-      [currentLayer resizeRoot:true];
+      [currentLayer resizeToFitChildrenWithOption:1];
     }
   }
 }
@@ -136,7 +135,7 @@ var collectMeasuresRecursively = function(currentLayer, styleTree, computedStyle
 
   // iterate over children recursively if we can
   if (utils.is.group(currentLayer)){
-    var childLayers = [currentLayer layers].array();
+    var childLayers = [currentLayer layers];
     var childStyleTree = styleTree["children"];
     var childComputedTree = computedStyleTree["children"];
     if (childLayers){
@@ -183,7 +182,7 @@ var layerTreeWithStylesheet = function(stylesheet, layer){
 
   // iterate over children recursively if we can
   if (utils.is.group(layer)){
-    var childLayers = [layer layers].array();
+    var childLayers = [layer layers];
     if (childLayers){
       var childrenArray = [];
       var loop = [childLayers objectEnumerator];

--- a/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.cssParser.js
+++ b/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.cssParser.js
@@ -14,7 +14,7 @@ var parseStyleSheetLayer = function() {
 // get the styleSheet layer
 var getStyleSheetLayer = function(layerName){
   var layer = nil;
-  var pageLayers = [page layers].array();
+  var pageLayers = [page layers];
   if (pageLayers) {
     var loop = [pageLayers objectEnumerator];
        while (item = [loop nextObject]) {

--- a/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.prototypes.js
+++ b/Flex-Layout.sketchplugin/Contents/Sketch/Layout/layout.prototypes.js
@@ -72,7 +72,7 @@ var parseLayersForPrototypes = function(baseLayer,shouldCollectStyles){
         utils.UI.showMessage(baseLayer.name() + " has no styles attached");
       }
     }
-    var childLayers = [baseLayer layers].array();
+    var childLayers = [baseLayer layers];
     if (childLayers){
       for (var i=0; i < [childLayers count]; i++){
         var item = childLayers[i];
@@ -108,7 +108,7 @@ var collectAttributes = function(layer){
   var attributes = {};
 
   // iterate over child layers to look for style layers
-  var childLayers = [layer layers].array();
+  var childLayers = [layer layers];
 
   for (var i = 0; i < [childLayers count]; i++) {
     var styleLayer = childLayers[i];

--- a/Flex-Layout.sketchplugin/Contents/Sketch/Layout/utils.js
+++ b/Flex-Layout.sketchplugin/Contents/Sketch/Layout/utils.js
@@ -63,7 +63,7 @@ utils.call = {
   childLayers : function(layer, callback){
     callback(layer);
     if (utils.is.group(layer)) {
-      var childLayers = [layer layers].array();
+      var childLayers = [layer layers];
       if (childLayers) {
         for (var i = 0; i < childLayers.count(); i++) {
           utils.call.childLayers(childLayers[i], callback);


### PR DESCRIPTION
This PR makes the plugin work on the latest version (v40) of Sketch as of today.
- Remove `array()` after getting `layers` as it already returns an array.
- Change `resizeRoot:true` to `resizeToFitChildrenWithOption:1`. Pointed
  in #18 too.
- Remove call to MSContentDrawView refresh's method [as it was
  removed](https://github.com/BohemianCoding/developer.sketchapp.com/issues/30).
  This is pointed in #18 too.

Fixes #21, #20, #18, #17 and #16.
